### PR TITLE
log-observe plug added

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,7 @@ apps:
     - network-bind
     - time-control
     - hardware-observe
+    - log-observe
     - mount-observe
     - network-observe
     - system-observe


### PR DESCRIPTION
Currently, apparmor emits the following denies:


```
apparmor="DENIED" operation="capable" class="cap" profile="snap.node-exporter.node-exporter" pid=4336 comm="node_exporter" capability=2  capname="dac_read_search"
apparmor="DENIED" operation="capable" class="cap" profile="snap.node-exporter.node-exporter" pid=4336 comm="node_exporter" capability=1  capname="dac_override"
```

The [log-observe interface has these capabilities enabled](https://github.com/canonical/snapd/blob/acf0dbd328661b222c295aace125ab874b56380a/interfaces/builtin/log_observe.go#L74): dac_read_search, dac_override