### PR TITLE
login-session-observe interface added

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,7 @@ apps:
     #   web:
     #     listen-stream: "[::]:9100"
     plugs:
+    - login-session-observe
     - network-bind
     - time-control
     - hardware-observe


### PR DESCRIPTION
This interface prevents this kind of error logs:

```shell
2025-08-29T17:45:18.698937-03:00 snapd-pr node-exporter.node-exporter[12178]: time=2025-08-29T20:45:18.698Z level=ERROR source=collector.go:168 msg="collector failed" name=logind duration_seconds=0.005156299 err="unable to get seats: An AppArmor policy prevents this sender from sending this message to this recipient; type=\"method_call\", sender=\":1.73\" (uid=0 pid=12178 comm=\"/snap/node-exporter/x1/bin/node_exporter --collect\" label=\"snap.node-exporter.node-exporter (enforce)\") interface=\"org.freedesktop.login1.Manager\" member=\"ListSeats\" error name=\"(unset)\" requested_reply=\"0\" destination=\"org.freedesktop.login1\" (uid=0 pid=825 comm=\"/usr/lib/systemd/systemd-logind\" label=\"unconfined\")"
```

More info:
https://forum.snapcraft.io/t/how-to-enable-a-listseats-dbus-call-for-a-strictly-confined-snap/48368