### PR TITLE
fix: add workaround plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ sudo snap connect node-exporter:hardware-observe
 sudo snap connect node-exporter:mount-observe
 sudo snap connect node-exporter:network-observe
 sudo snap connect node-exporter:system-observe
+sudo snap connect node-exporter:proc-sys-kernel-random
 ```
 
 ## Configuration

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,22 @@ confinement: strict
 base: core24
 adopt-info: node-exporter
 
+plugs:
+  proc-sys-kernel-random:
+    interface: system-files
+    read:
+      - /proc/buddyinfo
+      - /proc/slabinfo
+      - /proc/softirqs
+      - /proc/sys/kernel/random/poolsize
+      - /proc/sys/kernel/random/urandom_min_reseed_secs
+      - /proc/sys/kernel/random/write_wakeup_threshold
+      - /proc/sys/kernel/threads-max
+      - /sys/fs/btrfs
+      - /sys/kernel/mm/ksm/full_scans
+      - /sys/kernel/mm/ksm/merge_across_nodes
+      - /sys/kernel/mm/ksm/pages_shared
+
 parts:
   wrapper:
     plugin: dump
@@ -51,3 +67,4 @@ apps:
     - mount-observe
     - network-observe
     - system-observe
+    - proc-sys-kernel-random

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,10 @@ base: core24
 adopt-info: node-exporter
 
 plugs:
+  # This plug should be removed when these snapd PRs are merged:
+  # https://github.com/canonical/snapd/pull/15844
+  # https://github.com/canonical/snapd/pull/15895
+  # https://github.com/canonical/snapd/pull/15896
   proc-sys-kernel-random:
     interface: system-files
     read:


### PR DESCRIPTION
This PR adds a workaround plug to access system's files.

It is a temporary workaround which should be removed when these PR in snapd are merged and released


- https://github.com/canonical/snapd/pull/15844
- https://github.com/canonical/snapd/pull/15895
- https://github.com/canonical/snapd/pull/15896