### PR TITLE
Add read access to /etc/node-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ sudo snap connect node-exporter:mount-observe
 sudo snap connect node-exporter:network-observe
 sudo snap connect node-exporter:system-observe
 sudo snap connect node-exporter:proc-sys-kernel-random
+sudo snap connect node-exporter:etc-node-exporter
 ```
 
 ## Configuration

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,11 @@ plugs:
       - /sys/kernel/mm/ksm/full_scans
       - /sys/kernel/mm/ksm/merge_across_nodes
       - /sys/kernel/mm/ksm/pages_shared
+  etc-node-exporter:
+    interface: system-files
+    read:
+      # General-purpose config folder for e.g. `--collector.textfile.directory`
+      - /etc/node-exporter/
 
 parts:
   wrapper:
@@ -72,3 +77,4 @@ apps:
     - network-observe
     - system-observe
     - proc-sys-kernel-random
+    - etc-node-exporter


### PR DESCRIPTION
This PR adds a read plug for a general-purpose config folder, `/etc/node-exporter/`, for e.g. `--collector.textfile.directory`.