### PR TITLE
remove custom plug since all PR were merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,6 @@
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 
 
-## Post-installation
-
-The `node-exporter` snap requires some interfaces to be manually connected in order to grant permission to collect certain metrics. Without these connections, only basic metrics are available. To connect all exposed interfaces, run the following commands after installation:
-
-```bash
-sudo snap connect node-exporter:hardware-observe
-sudo snap connect node-exporter:mount-observe
-sudo snap connect node-exporter:network-observe
-sudo snap connect node-exporter:system-observe
-sudo snap connect node-exporter:proc-sys-kernel-random
-```
-
 ## Configuration
 
 Collectors can be enabled/disabled using the `collectors` and `no-collectors` configuration options with this snap. To specify multiple collectors, use a quoted string with space-separated values. For example:
@@ -56,18 +44,3 @@ sudo snap set node-exporter no-collectors="mdadm netstat"
 ```
 
 Reference the [prometheus/node_exporter README.md](https://github.com/prometheus/node_exporter/blob/master/README.md#collectors) for the list of collectors enabled by default.
-
-
-## Known issues
-
-Currently this strictly confined snap has no access to system files that prevents the following collectors from operating correctly:
-
-- buddyinfo
-- logind
-- mountstats
-- slabinfo
-- softirqs
-
-For more details read:
-
-https://forum.snapcraft.io/t/should-some-snapd-interfaces-be-modified/48242

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,26 +11,6 @@ confinement: strict
 base: core24
 adopt-info: node-exporter
 
-plugs:
-  # This plug should be removed when these snapd PRs are merged:
-  # https://github.com/canonical/snapd/pull/15844
-  # https://github.com/canonical/snapd/pull/15895
-  # https://github.com/canonical/snapd/pull/15896
-  proc-sys-kernel-random:
-    interface: system-files
-    read:
-      - /proc/buddyinfo
-      - /proc/slabinfo
-      - /proc/softirqs
-      - /proc/sys/kernel/random/poolsize
-      - /proc/sys/kernel/random/urandom_min_reseed_secs
-      - /proc/sys/kernel/random/write_wakeup_threshold
-      - /proc/sys/kernel/threads-max
-      - /sys/fs/btrfs
-      - /sys/kernel/mm/ksm/full_scans
-      - /sys/kernel/mm/ksm/merge_across_nodes
-      - /sys/kernel/mm/ksm/pages_shared
-
 parts:
   wrapper:
     plugin: dump
@@ -71,4 +51,3 @@ apps:
     - mount-observe
     - network-observe
     - system-observe
-    - proc-sys-kernel-random


### PR DESCRIPTION
This PR removes a custom plug, since it is no longer necessary:


```diff
-plugs:
-  # This plug should be removed when these snapd PRs are merged:
-  # https://github.com/canonical/snapd/pull/15844
-  # https://github.com/canonical/snapd/pull/15895
-  # https://github.com/canonical/snapd/pull/15896
-  proc-sys-kernel-random:
-    interface: system-files
-    read:
-      - /proc/buddyinfo
-      - /proc/slabinfo
-      - /proc/softirqs
-      - /proc/sys/kernel/random/poolsize
-      - /proc/sys/kernel/random/urandom_min_reseed_secs
-      - /proc/sys/kernel/random/write_wakeup_threshold
-      - /proc/sys/kernel/threads-max
-      - /sys/fs/btrfs
-      - /sys/kernel/mm/ksm/full_scans
-      - /sys/kernel/mm/ksm/merge_across_nodes
-      - /sys/kernel/mm/ksm/pages_shared
```