### PR TITLE
feature: config option for `web.listen-address` added

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 
 ## Configuration
 
+### Collectors
+
 Collectors can be enabled/disabled using the `collectors` and `no-collectors` configuration options with this snap. To specify multiple collectors, use a quoted string with space-separated values. For example:
 
 ```bash
@@ -44,3 +46,24 @@ sudo snap set node-exporter no-collectors="mdadm netstat"
 ```
 
 Reference the [prometheus/node_exporter README.md](https://github.com/prometheus/node_exporter/blob/master/README.md#collectors) for the list of collectors enabled by default.
+
+### Listen Address
+
+The listen address and port can be configured using the `web.listen-address` option. The default is `:9100` (all interfaces on port 9100). For example:
+
+```bash
+# Change port only (all interfaces)
+sudo snap set node-exporter web.listen-address=":9200"
+
+# Bind to specific IPv4 address and port
+sudo snap set node-exporter web.listen-address="127.0.0.1:9100"
+
+# Bind to specific IPv6 address and port
+sudo snap set node-exporter web.listen-address="[::1]:9100"
+```
+
+To verify the configuration was applied successfully and check for any errors, view the service logs:
+
+```bash
+sudo journalctl -u snap.node-exporter.node-exporter -n 50
+```

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ sudo snap set node-exporter web.listen-address="[::1]:9100"
 To verify the configuration was applied successfully and check for any errors, view the service logs:
 
 ```bash
-sudo journalctl -u snap.node-exporter.node-exporter -n 50
+sudo snap logs node-exporter
 ```

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -26,6 +26,11 @@ done
 web_listen_address="$(snapctl get web.listen-address)"
 
 if [ -n "$web_listen_address" ]; then
+    # Reject values containing whitespace or obvious shell metacharacters
+    if printf '%s' "$web_listen_address" | grep '[[:space:];&|`$<>]' >/dev/null 2>&1; then
+        echo "Invalid web.listen-address: must not contain whitespace or shell metacharacters" >&2
+        exit 1
+    fi
     flags="${flags} --web.listen-address=$web_listen_address"
 fi
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -34,5 +34,5 @@ if [ -n "$web_listen_address" ]; then
     flags="${flags} --web.listen-address=$web_listen_address"
 fi
 
-echo "$flags" > $SNAP_DATA/flags
+printf '%s\n' "$flags" > "$SNAP_DATA/flags"
 snapctl restart node-exporter

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -23,5 +23,11 @@ for no_collector in $no_collectors; do
     flags="${flags} --no-collector.$no_collector"
 done
 
+web_listen_address="$(snapctl get web.listen-address)"
+
+if [ -n "$web_listen_address" ]; then
+    flags="${flags} --web.listen-address=$web_listen_address"
+fi
+
 echo "$flags" > $SNAP_DATA/flags
 snapctl restart node-exporter


### PR DESCRIPTION
## Description

This PR fixes https://github.com/canonical/node-exporter-snap/issues/6 
It adds support for configuring the `web.listen-address` option in node-exporter, allowing users to customize the listening address and port.
     
**Changes:**
- Extended the `configure` hook to handle the `web.listen-address` configuration option
- Updated README.md with usage examples and troubleshooting instructions
- The configuration key mirrors the upstream flag name (`web.listen-address`) for consistency
     
This feature is a necessary condition to solve this issue: https://github.com/canonical/opentelemetry-collector-operator/issues/176
     
## Manual Testing Steps
     
### Prerequisites
```bash
# Build the snap from this branch
snapcraft pack
     
# Install it locally
sudo snap install --dangerous node-exporter_*.snap
```

### Tests
```shell
Test 1: Change port (all interfaces)

# Configure to listen on port 9200
sudo snap set node-exporter web.listen-address=":9200"
     
# Verify the service restarted successfully
sudo snap services node-exporter
     
# Test the new endpoint
curl http://localhost:9200/metrics
     
# Verify in logs
sudo journalctl -u snap.node-exporter.node-exporter | grep "Listening on"

Test 2: Bind to specific IPv4 address

# Configure to listen only on localhost
sudo snap set node-exporter web.listen-address="127.0.0.1:9100"
     
# Verify it's not accessible from other interfaces
curl http://localhost:9100/metrics  # Should work
curl http://$(hostname -I | awk '{print $1}'):9100/metrics  # Should fail
     
# Check logs for any errors
sudo journalctl -u snap.node-exporter.node-exporter -n 50

Test 3: Bind to IPv6 address

# Configure for IPv6 localhost
sudo snap set node-exporter web.listen-address="[::1]:9100"
     
# Test IPv6 endpoint
curl http://[::1]:9100/metrics | head -n 5
     
# Verify in logs
sudo journalctl -u snap.node-exporter.node-exporter -n 50

Test 4: Invalid address handling

# Try an invalid format
sudo snap set node-exporter web.listen-address="invalid::"
     
# Service should fail to start - check logs for error message
sudo journalctl -u snap.node-exporter.node-exporter -n 50 | grep ERROR
     
# Expected error: "listen tcp: address invalid::: too many colons in address"

Test 5: Reset to default

# Unset the configuration
sudo snap unset node-exporter web.listen-address
     
# Verify it's back to default port 9100 on all interfaces
curl http://localhost:9100/metrics

Test 6: Check configuration persistence

# Set a custom port
sudo snap set node-exporter web.listen-address=":9200"
     
# Verify the flag was saved
cat /var/snap/node-exporter/current/flags
     
# Restart the service
sudo snap restart node-exporter
     
# Verify configuration persisted after restart
curl http://localhost:9200/metrics
```