### PR TITLE
feat: add support for collector.textfile.directory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,18 @@ To verify the configuration was applied successfully and check for any errors, v
 ```bash
 sudo snap logs node-exporter
 ```
+
+### Textfile Collector Directory
+
+The textfile collector reads metrics from `.prom` files placed in a directory. To configure the directory:
+
+```bash
+sudo snap set node-exporter collector.textfile.directory=/var/snap/node-exporter/common/textfile_collector
+```
+
+> **Note:** Due to strict snap confinement, the directory must be accessible to the snap. The recommended path is under `$SNAP_COMMON` (`/var/snap/node-exporter/common/`). Create the directory before enabling the collector:
+>
+> ```bash
+> mkdir -p /var/snap/node-exporter/common/textfile_collector
+> sudo snap set node-exporter collector.textfile.directory=/var/snap/node-exporter/common/textfile_collector
+> ```

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -34,5 +34,15 @@ if [ -n "$web_listen_address" ]; then
     flags="${flags} --web.listen-address=$web_listen_address"
 fi
 
+textfile_directory="$(snapctl get collector.textfile.directory)"
+
+if [ -n "$textfile_directory" ]; then
+    if printf '%s' "$textfile_directory" | grep '[[:space:];&|`$<>]' >/dev/null 2>&1; then
+        echo "Invalid collector.textfile.directory: must not contain whitespace or shell metacharacters" >&2
+        exit 1
+    fi
+    flags="${flags} --collector.textfile.directory=$textfile_directory"
+fi
+
 printf '%s\n' "$flags" > "$SNAP_DATA/flags"
 snapctl restart node-exporter


### PR DESCRIPTION
## Summary

This PR adds support for configuring the `textfile` collector directory via `snap set`, allowing users to point node_exporter to a custom `.prom` files directory.

It is needed to solve: 

- https://github.com/canonical/opentelemetry-collector-operator/issues/108
- https://github.com/canonical/opentelemetry-collector-operator/issues/98#issuecomment-3415853229
 
## Changes
 
- **`snap/hooks/configure`**: Added handling for the `collector.textfile.directory` snapctl key. When set, it appends `--collector.textfile.directory=<path>` to the node_exporter flags, following the same validation pattern used for `web.listen-address` (rejects values containing whitespace or shell metacharacters).
 
- **`README.md`**: Documented the new configuration option, including the recommended path under `$SNAP_COMMON` due to strict confinement restrictions.
 
## Usage
 
```shell
sudo mkdir -p /var/snap/node-exporter/common/textfile_collector

sudo snap set node-exporter collector.textfile.directory=/var/snap/node-exporter/common/textfile_collector
```

**Note:** Due to strict snap confinement, the directory must be accessible to the snap. The recommended path is under `$SNAP_COMMON` (`/var/snap/node-exporter/common/`).

## Testing

1. Pack the snap
  ```shell
  snapcraft pack
  ```

2. Install the snap
  ```shell
  sudo snap install node-exporter_v1.11.1_amd64.snap --dangerous
  ```

3. Verify `node-exporter` is running
  ```shell
  ps ax | grep node-exporter                                 
  1940115 ?        Ssl    0:00 /snap/node-exporter/x1/bin/node_exporter
  ```

4. Configure the new collector
  ```shell
  sudo snap set node-exporter  collector.textfile.directory="/var/snap/node-exporter/common/textfile_collector"
  ```

5. Verify the new collector configuration was set:
  ```shell
  ps ax | grep node_exporter
  1940921 ?        Ssl    0:00 /snap/node-exporter/x1/bin/node_exporter --collector.textfile.directory=/var/snap/node-exporter/common/textfile_collector
  ```