### PR TITLE
feat: add riscv64 to platforms list

### DIFF
--- a/latest/snap/snapcraft.yaml
+++ b/latest/snap/snapcraft.yaml
@@ -16,6 +16,7 @@ platforms:
   arm64:
   ppc64el:
   s390x:
+  riscv64:
 
 parts:
   wrapper:


### PR DESCRIPTION
In the current release view, the riscv64 manual release is dated and not being auto-built.
This PR adds riscv64 to the platforms list.

<img width="2404" height="910" alt="image" src="https://github.com/user-attachments/assets/4af53e5d-8692-4831-8284-b8982b987673" />
